### PR TITLE
Bug fix - was not moving to interpolated Z position after rapid to new

### DIFF
--- a/pcbGcodeZprobing.py
+++ b/pcbGcodeZprobing.py
@@ -126,6 +126,7 @@ def main():
     XMax = -10000
     YMin = 10000
     YMax = -10000
+    Gval = 0;
 
     infile = sys.argv[1]
     f = open(infile, "r")
@@ -386,9 +387,9 @@ M3
             Gval = int(match.group(1))
 
         # extract the X coordinate from the line
-        match = re.match(".*X(-*\d*\.*\d*)",line)
-        if match:
-            X_dest = float(match.group(1))
+        xmatch = re.match(".*X(-*\d*\.*\d*)",line)
+        if xmatch:
+            X_dest = float(xmatch.group(1))
 
         # and also the Y coordinate
         match = re.match(".*Y(-*\d*\.*\d*)",line)
@@ -398,7 +399,11 @@ M3
         # if the move as a milling move (G01), replace it with a subroutine call
         if Gval == 1:
             print('O200 call [%.4f] [%.4f] [%.4f] [%.4f]\n' % (X_start, Y_start, X_dest, Y_dest),end="")
-        # anything that is not a G1/G01 is simply copied to output
+        #if this is a rapid to a new position (G00 X* Y*), then need to move to new position, then output a subroutine call to get to proper Z depth for that position, before making G01 move to next destination
+        elif Gval == 0 and xmatch:
+            print(line)
+            print('O200 call [%.4f] [%.4f] [%.4f] [%.4f]\n' % (X_dest, Y_dest, X_dest, Y_dest),end="")
+        # anything that is not a G1/G01, or not a G00 X* is simply copied to output
         else:
             print(line)
     print("M5 (spindle off)")


### PR DESCRIPTION
XY position, resulting in missed etching moves (as Z would be part of
G1 to destination, thus milling air on the downward diagonal descent).
Also,  Python was throwing an UnboundLocalError over Gval variable, so
declared at ‘main’ function level.

See visual example below:

Original - rapid to new position, then start etch to next waypoint, w/o first moving down to interpolated Z for starting point
![etchwithoutinterpolatedz](https://cloud.githubusercontent.com/assets/3118745/22628111/4a9bacf2-eb9c-11e6-82b9-f138acc263c5.png)

Fixed - rapid to new position, move down to interpolated Z for that position, then move to next waypoint (this is how its done in Matt Venn's original code)
![etchwithinterpolatedz](https://cloud.githubusercontent.com/assets/3118745/22628110/4a93cf32-eb9c-11e6-83af-1029b8a2426e.png)
